### PR TITLE
fix: _spliceArrayValue bug with field using bracket notation name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -798,19 +798,19 @@ class Field {
          * case 2: names=['key.0.name', 'key.0.email', 'key.1.name', 'key.1.email'], should delete 'key.1.name', 'key.1.email'
          */
         const listMap = {};
-        const keyReg = new RegExp(`^${key}.(\\d+)`);
+        const keyReg = new RegExp(`^(${key}.)(\\d+)`);
         const replaceArgv = [];
         const names = this.getNames();
         names.forEach(n => {
             const ret = keyReg.exec(n);
             if (ret) {
-                const idx = parseInt(ret[1]);
+                const idx = parseInt(ret[2]);
 
                 if (idx >= startIndex) {
                     let l = listMap[idx];
                     const item = {
                         from: n,
-                        to: `${key}.${idx - offset}${n.replace(ret[0], '')}`,
+                        to: n.replace(keyReg, (match, p1) => `${p1}${idx - offset}`),
                     };
                     if (!l) {
                         listMap[idx] = [item];

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -770,6 +770,33 @@ describe('field', () => {
                 assert(field.getValue('key2.3.id') === undefined);
 
             });
+
+            it('should remove field with name using bracket notation', () => {
+                const field = new Field(this, { parseName: true });
+                field.init('key2[0].id', { initValue: 0 });
+                field.init('key2[1].id', { initValue: 1 });
+                field.init('key2[2].id', { initValue: 2 });
+                field.init('key2[3].id', { initValue: 3 });
+
+                field.deleteArrayValue('key2', 1);
+                assert(field.getValue('key2[0].id') === 0);
+                assert(field.getValue('key2[1].id') === 2);
+                assert(field.getValue('key2[2].id') === 3);
+                assert(field.getValue('key2[3].id') === undefined);
+
+                field.deleteArrayValue('key2', 1);
+                assert(field.getValue('key2[0].id') === 0);
+                assert(field.getValue('key2[1].id') === 3);
+                assert(field.getValue('key2[2].id') === undefined);
+                assert(field.getValue('key2[3].id') === undefined);
+
+                field.deleteArrayValue('key2', 0);
+                assert(field.getValue('key2[0].id') === 3);
+                assert(field.getValue('key2[1].id') === undefined);
+                assert(field.getValue('key2[2].id') === undefined);
+                assert(field.getValue('key2[3].id') === undefined);
+            });
+
             it('should remove 2 field item with deleteArrayValue(key,index,2)', () => {
                 const field = new Field(this, { parseName: true });
                 field.init('key.0', { initValue: 0 });


### PR DESCRIPTION
Field name with bracket notation is supported in getting/setting value, but it doesn't work correctly with deleteArrayValue.
This PR fixs it.