### PR TITLE
fix: getError and getErrors return type declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -282,13 +282,13 @@ export default class Field  {
     /**
      * 获取单个输入控件的 Error
      */
-    getError(name: string): null | string[] | string;
+    getError(name: string): null | string[];
 
     /**
      * 获取一组输入控件的 Error
      * @param names 字段名
      */
-    getErrors(names?: string[]): null | string[] | string;
+    getErrors(names?: string[]): object;
 
     /**
      * 设置单个输入控件的 Error

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -282,13 +282,13 @@ export default class Field  {
     /**
      * 获取单个输入控件的 Error
      */
-    getError(name: string): Error;
+    getError(name: string): null | string[] | string;
 
     /**
      * 获取一组输入控件的 Error
      * @param names 字段名
      */
-    getErrors(names?: string[]): Error;
+    getErrors(names?: string[]): null | string[] | string;
 
     /**
      * 设置单个输入控件的 Error


### PR DESCRIPTION
1. 修正 getError getErrors这两个函数的返回值类型声明。 js 代码中返回的是 null 或者 Array
2. 同时和 setError 的时候接收类型保持一致。 添加了直接 string 支持